### PR TITLE
Deprecated PHP correction

### DIFF
--- a/zklib/zkconst.php
+++ b/zklib/zkconst.php
@@ -143,24 +143,25 @@
 
         copied from zkemsdk.c - DecodeTime*/
         $second = $t % 60;
-        $t = $t / 60;
-
+        $t = intval($t / 60);
+    
         $minute = $t % 60;
-        $t = $t / 60;
-
+        $t = intval($t / 60);
+    
         $hour = $t % 24;
-        $t = $t / 24;
-
-        $day = $t % 31+1;
-        $t = $t / 31;
-
-        $month = $t % 12+1;
-        $t = $t / 12;
-
-        $year = floor( $t + 2000 );
-
-        $d = date("Y-m-d H:i:s", strtotime( $year.'-'.$month.'-'.$day.' '.$hour.':'.$minute.':'.$second) );
-        
+        $t = intval($t / 24);
+    
+        $day = $t % 31 + 1;
+        $t = intval($t / 31);
+    
+        $month = $t % 12 + 1;
+        $t = intval($t / 12);
+    
+        $year = floor($t + 2000);
+    
+        $d = date("Y-m-d H:i:s", strtotime($year . '-' . $month . '-' . $day . ' ' . $hour . ':' . $minute . ':' . $second));
+    
         return $d;
+
     }
 ?>

--- a/zklib/zklib.php
+++ b/zklib/zklib.php
@@ -87,7 +87,7 @@
             $u = unpack('S', $this->createChkSum($buf));
             
             if ( is_array( $u ) ) {
-                while( list( $key ) = each( $u ) ) {
+                foreach ($u as $key => $value) {
                     $u = $u[$key];
                     break;
                 }

--- a/zklib/zkuser.php
+++ b/zklib/zkuser.php
@@ -116,7 +116,7 @@
                     $userid = explode( chr(0), $userid, 2);
                     $userid = $userid[0];
                     $name = explode(chr(0), $name, 3);
-                    $name = utf8_encode($name[0]);
+                    $name = iconv('ISO-8859-1', 'UTF-8', $name[0]);
                     $cardno = str_pad($cardno,11,'0',STR_PAD_LEFT);
                     
                     if ( $name == "" )

--- a/zktest.php
+++ b/zktest.php
@@ -5,9 +5,12 @@
     
     <body>
 <?php
+ini_set('display_errors', 0); 
+ini_set('display_startup_errors', 0); 
+error_reporting(E_ALL);
     include("zklib/zklib.php");
     
-    $zk = new ZKLib("192.168.1.201", 4370);
+    $zk = new ZKLib("192.168.1.205", 4370);
     
     $ret = $zk->connect();
 
@@ -67,13 +70,15 @@
                 //$zk->setUser(1, '1', 'Admin', '', LEVEL_ADMIN);
                 $user = $zk->getUser();
                 sleep(1);
-                while(list($uid, $userdata) = each($user)):
+                // while(list($uid, $userdata) = each($user)):
+                foreach ($user as $uid => $userdata) {
                     if ($userdata[2] == LEVEL_ADMIN)
                         $role = 'ADMIN';
                     elseif ($userdata[2] == LEVEL_USER)
                         $role = 'USER';
                     else
                         $role = 'Unknown';
+                
                 ?>
                 <tr>
                     <td><?php echo $uid ?></td>
@@ -82,8 +87,9 @@
                     <td><?php echo $role ?></td>
                     <td><?php echo $userdata[3] ?>&nbsp;</td>
                 </tr>
+
                 <?php
-                endwhile;
+                };
             } catch (Exception $e) {
                 header("HTTP/1.0 404 Not Found");
                 header('HTTP', true, 500); // 500 internal server error                
@@ -107,11 +113,12 @@
             <?php
             $attendance = $zk->getAttendance();
             sleep(1);
-            while(list($idx, $attendancedata) = each($attendance)):
+            foreach ($attendance as $idx => $attendancedata) {
                 if ( $attendancedata[2] == 14 )
                     $status = 'Check Out';
                 else
                     $status = 'Check In';
+
             ?>
             <tr>
                 <td><?php echo $idx ?></td>
@@ -122,7 +129,7 @@
                 <td><?php echo date( "H:i:s", strtotime( $attendancedata[3] ) ) ?></td>
             </tr>
             <?php
-            endwhile
+            }
             ?>
         </table>
         


### PR DESCRIPTION
In PHP, the each function has been deprecated starting from PHP 7.2, and it's removed as of PHP 8.0. Instead, i can use foreach to iterate over an array.